### PR TITLE
Support for Flycast v2.2

### DIFF
--- a/DemulShooterX64/Games/Game_Flycast.cs
+++ b/DemulShooterX64/Games/Game_Flycast.cs
@@ -50,6 +50,7 @@ namespace DemulShooterX64
         {
             _KnownMd5Prints.Add("Flycast v2.0", "84b08b9aa61d8c46ff47abcc77f690f7");
             _KnownMd5Prints.Add("Flycast v2.1", "cf56b386e1a9e82f5a92f8aadb2b6df9");
+            _KnownMd5Prints.Add("Flycast v2.2", "1fa2952ada82345ae743bc9110c6dbec");
             _tProcess.Start();
             Logger.WriteLog("Waiting for Flycast " + _RomName + " game to hook.....");
         }


### PR DESCRIPTION
Was unsure if the pointers themselves are stored anywhere within the repo or if the MemoryData files are just added to the releases, in which case I found the pointer for Flycast v2.2 is 0x237BB90