### PR TITLE
new argument for forcing md5 hash

### DIFF
--- a/DemulShooter/Games/Game.cs
+++ b/DemulShooter/Games/Game.cs
@@ -7,6 +7,7 @@ using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Security.Cryptography;
 using System.Text;
+using System.Text.RegularExpressions;
 using System.Timers;
 using DsCore;
 using DsCore.Config;
@@ -169,6 +170,15 @@ namespace DemulShooter
         {
             if (File.Exists(FileName))
             {
+                if(Program.CustomMD5 != String.Empty)
+                {
+					Regex md5Regex = new Regex("^[a-fA-F0-9]{32}$");
+                    if (md5Regex.IsMatch(Program.CustomMD5))
+                    {
+						_TargetProcess_Md5Hash = Program.CustomMD5.ToLower();
+						return;
+					}
+				}
                 using (var md5 = MD5.Create())
                 {
                     using (var stream = File.OpenRead(FileName))

--- a/DemulShooter/Program.cs
+++ b/DemulShooter/Program.cs
@@ -25,11 +25,14 @@ namespace DemulShooter
         static String strTarget = string.Empty;
         static String strRom = string.Empty;
         static String strCustomTargetProcessName = string.Empty;
-        public static String CustomTargetProcessName
+		public static String CustomTargetProcessName
         { get {return strCustomTargetProcessName;} }
 
+		static String strCustomMD5 = string.Empty;
+		public static String CustomMD5
+		{ get {return strCustomMD5;} }
 
-        static void Main(string[] args)
+		static void Main(string[] args)
         {
             // Attach to the parent process via AttachConsole SDK call
             AttachConsole(ATTACH_PARENT_PROCESS);
@@ -303,7 +306,12 @@ namespace DemulShooter
                         if (strCustomTargetProcessName.EndsWith(".exe"))
                             strCustomTargetProcessName = strCustomTargetProcessName.Substring(0, strCustomTargetProcessName.Length - 4);
                     }
-                }
+
+					else if (args[i].ToLower().StartsWith("-forcemd5"))
+					{
+						strCustomMD5 = (args[i].ToLower().Split('='))[1].Trim();
+					}
+				}
 
                 if (strTarget == String.Empty)
                 {

--- a/DemulShooterX64/Games/Game.cs
+++ b/DemulShooterX64/Games/Game.cs
@@ -7,6 +7,7 @@ using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Security.Cryptography;
 using System.Text;
+using System.Text.RegularExpressions;
 using System.Timers;
 using DsCore;
 using DsCore.Config;
@@ -161,7 +162,16 @@ namespace DemulShooterX64
         {
             if (File.Exists(FileName))
             {
-                using (var md5 = MD5.Create())
+				if (Program.CustomMD5 != String.Empty)
+				{
+					Regex md5Regex = new Regex("^[a-fA-F0-9]{32}$");
+					if (md5Regex.IsMatch(Program.CustomMD5))
+					{
+						_TargetProcess_Md5Hash = Program.CustomMD5.ToLower();
+						return;
+					}
+				}
+				using (var md5 = MD5.Create())
                 {
                     using (var stream = File.OpenRead(FileName))
                     {

--- a/DemulShooterX64/Program.cs
+++ b/DemulShooterX64/Program.cs
@@ -29,7 +29,11 @@ namespace DemulShooterX64
         public static String CustomTargetProcessName
         { get { return strCustomTargetProcessName; } }
 
-        static void Main(string[] args)
+		static String strCustomMD5 = string.Empty;
+		public static String CustomMD5
+		{ get { return strCustomMD5; } }
+
+		static void Main(string[] args)
         {
             // Attach to the parent process via AttachConsole SDK call
             AttachConsole(ATTACH_PARENT_PROCESS);
@@ -188,7 +192,12 @@ namespace DemulShooterX64
                             strCustomTargetProcessName = strCustomTargetProcessName.Substring(0, strCustomTargetProcessName.Length - 4);
                     }
 
-                }
+					else if (args[i].ToLower().StartsWith("-forcemd5"))
+					{
+						strCustomMD5 = (args[i].ToLower().Split('='))[1].Trim();
+					}
+
+				}
 
                 if (strTarget == String.Empty)
                 {


### PR DESCRIPTION
Use case, sometime i slightly edit some games to change some minor stuff, like resolution increase even if that's imperfect. (like the ui wont scale or things like that)
Instead of adding md5 for every possible variation of a file (like each resolution from 720p to 4k of a game), i think it would be nice to have an option to force demulshooter to use an user specified value as md5.
Make things easier for testing, tweaking stuff.
