### PR TITLE
add tcp input server  to support linux with wine

### DIFF
--- a/DemulShooter/DemulShooter.csproj
+++ b/DemulShooter/DemulShooter.csproj
@@ -170,6 +170,7 @@
       <DependentUpon>Settings.settings</DependentUpon>
     </Compile>
     <Compile Include="DemulShooterWindow.cs" />
+    <Compile Include="TcpInputServer.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\DsCore\DsCore.csproj">

--- a/DemulShooter/DemulShooterWindow.cs
+++ b/DemulShooter/DemulShooterWindow.cs
@@ -47,6 +47,10 @@ namespace DemulShooter
         private Net_OutputHelper _Net_OutputHelper;
         private Thread _OutputUpdateLoop;
 
+        //TCP Input server
+        private TcpInputServer _TcpInputServer;
+        private object _TcpInputSync = new object();
+
         //Game options
         private Game _Game;
         private string _Rom = String.Empty;
@@ -238,6 +242,32 @@ namespace DemulShooter
                 }
                 else
                     Logger.WriteLog("P" + Player.ID + " Gamepad ID = " + Player.GamepadID);
+            }
+
+            bool tcpInputEnabled = false;
+            foreach (PlayerSettings Player in Configurator.GetInstance().PlayersSettings)
+            {
+                if (Player.Mode == PlayerSettings.PLAYER_MODE_TCPINPUT)
+                {
+                    tcpInputEnabled = true;
+                    if (Player.RIController == null)
+                    {
+                        Player.RIController = new RawInputController();
+                        Player.RIController.SetDeviceName("[TCP Input P" + Player.ID + "]");
+                        Player.RIController.SetDeviceType(RawInputDeviceType.RIM_TYPEHID);
+                        Player.RIController.SetAxisRange(0, 0x0000FFFF, 0, 0x0000FFFF);
+                        Player.RIController.SetComputedCoordinates(0, 0);
+                        Player.RIController.SetComputedButtons(0);
+                    }
+                }
+            }
+
+            if (tcpInputEnabled)
+            {
+                int tcpPort = Configurator.GetInstance().TcpInputPort;
+                Logger.WriteLog("Starting TCP input server on port " + tcpPort);
+                _TcpInputServer = new TcpInputServer(ProcessTcpInputData, tcpPort);
+                _TcpInputServer.Start();
             }
 
             //Info on Monitor (max resolution)
@@ -1056,116 +1086,233 @@ namespace DemulShooter
                                     }
                                 }
 
-                                if (_EnableInputsIpc)
-                                    _MMF_Inputs.UpdateRawPlayerData(Player.ID, (UInt32)Player.RIController.Computed_X, (UInt32)Player.RIController.Computed_Y);
-
-                                _Game.GetScreenResolution();
-                                Logger.WriteLog("PrimaryScreen Size (Px) = [ " + _Game.ScreenWidth + "x" + _Game.ScreenHeight + " ]");
-
-                                if (!Controller.IsRelativeCoordinates)
-                                {
-                                    //If manual calibration override for analog guns
-                                    if (Player.RIController.DeviceType == RawInputDeviceType.RIM_TYPEHID && Player.AnalogAxisRangeOverride)
-                                    {
-                                        Logger.WriteLog("Overriding player axis range values : X => [ " + Player.AnalogManual_Xmin.ToString() + ", " + Player.AnalogManual_Xmax.ToString() + " ], Y => [ " + Player.AnalogManual_Ymin.ToString() + ", " + Player.AnalogManual_Ymax.ToString() + " ]");
-                                        Player.RIController.Computed_X = _Game.ScreenScale(Player.RIController.Computed_X, Player.AnalogManual_Xmin, Player.AnalogManual_Xmax, 0, _Game.ScreenWidth);
-                                        Player.RIController.Computed_Y = _Game.ScreenScale(Player.RIController.Computed_Y, Player.AnalogManual_Ymin, Player.AnalogManual_Ymax, 0, _Game.ScreenHeight);
-                                    }
-                                    else
-                                    {
-                                        Player.RIController.Computed_X = _Game.ScreenScale(Player.RIController.Computed_X, Player.RIController.Axis_X_Min, Player.RIController.Axis_X_Max, 0, _Game.ScreenWidth);
-                                        Player.RIController.Computed_Y = _Game.ScreenScale(Player.RIController.Computed_Y, Player.RIController.Axis_Y_Min, Player.RIController.Axis_Y_Max, 0, _Game.ScreenHeight);
-                                    }
-
-                                    //Optionnal invert axis
-                                    if (Player.InvertAxis_X)
-                                        Player.RIController.Computed_X = _Game.ScreenWidth - Player.RIController.Computed_X;
-                                    if (Player.InvertAxis_Y)
-                                        Player.RIController.Computed_Y = _Game.ScreenHeight - Player.RIController.Computed_Y;
-
-                                    Logger.WriteLog("OnScreen Cursor Position (Px) = [ " + Player.RIController.Computed_X + ", " + Player.RIController.Computed_Y + " ]");
-
-                                    if (Configurator.GetInstance().Act_Labs_Offset_Enable)
-                                    {
-                                        Player.RIController.Computed_X += Player.Act_Labs_Offset_X;
-                                        Player.RIController.Computed_Y += Player.Act_Labs_Offset_Y;
-                                        Logger.WriteLog("ActLabs adaptated OnScreen Cursor Position (Px) = [ " + Player.RIController.Computed_X + ", " + Player.RIController.Computed_Y + " ]");
-                                    }
-                                }
-
-                                //Change X asxis scaling based on user requirements
-                                if (_ForceScalingX != 1.0)
-                                {
-                                    Logger.WriteLog("Forcing X Scaling = " + _ForceScalingX.ToString());
-                                    double HalfScreenSize = (double)_Game.ScreenWidth / 2.0;
-                                    double NewX = (((double)Player.RIController.Computed_X - HalfScreenSize) * _ForceScalingX) + HalfScreenSize;
-                                    Player.RIController.Computed_X = Convert.ToInt32(NewX);
-                                    Logger.WriteLog("Forced scaled OnScreen Cursor Position (Px) = [ " + Player.RIController.Computed_X + ", " + Player.RIController.Computed_Y + " ]");
-                                }
-
-                                _Game.IsFullscreen = _Game.GetFullscreenStatus();
-                                if (!_Game.IsFullscreen)
-                                {
-                                    Logger.WriteLog("ClientWindow Style = Windowed");
-
-                                    //Retrieve info for debug/replay purpose
-                                    _Game.GetClientwindowInfo();
-
-                                    if (!_Game.ClientScale(Player))
-                                    {
-                                        Logger.WriteLog("Error converting screen location to client location");
-                                        return;
-                                    }
-                                    Logger.WriteLog("ClientWindow Location (px) = [ " + _Game.clientWindowLocation.X.ToString() + ", " + _Game.clientWindowLocation.Y.ToString() + " ]");
-                                    Logger.WriteLog("ClientWindow Size (px) = [ " + (_Game.WindowRect.Right - _Game.WindowRect.Left).ToString() + "x" + (_Game.WindowRect.Bottom - _Game.WindowRect.Top).ToString() + " ]");
-                                    Logger.WriteLog("OnClient Cursor Position (Px) = [ " + Player.RIController.Computed_X + ", " + Player.RIController.Computed_Y + " ]");
-
-                                    if (!_Game.GetClientRect())
-                                    {
-                                        Logger.WriteLog("Error getting client Rect");
-                                        return;
-                                    }
-                                }
-                                else
-                                {
-                                    Logger.WriteLog("ClientWindow Style = FullScreen");
-
-                                    //No need to translate coordinates from screen -> client and risk error.
-                                    //As fuulscreen, we will consider window size = screen size
-
-                                    Rect r = new Rect();
-                                    r.Top = 0;
-                                    r.Left = 0;
-                                    r.Bottom = _Game.ScreenHeight;
-                                    r.Right = _Game.ScreenWidth;
-                                    _Game.ClientRect = r;
-                                }
-
-                                if (!_Game.GameScale(Player))
-                                {
-                                    Logger.WriteLog("Error converting client location to game location");
-                                    return;
-                                }                                
-
-                                Logger.WriteLog("Game Position (Hex) = [ " + Player.RIController.Computed_X.ToString("X4") + ", " + Player.RIController.Computed_Y.ToString("X4") + " ]");
-                                Logger.WriteLog("Game Position (Dec) = [ " + Player.RIController.Computed_X.ToString() + ", " + Player.RIController.Computed_Y.ToString() + " ]");
-                                if (Controller.Computed_Buttons != 0)
-                                    Logger.WriteLog("Controller Buttons Events : " + Player.RIController.Computed_Buttons.ToString());
-                                Logger.WriteLog("-");
-
-                                if (!_NoInput)
-                                    _Game.SendInput(Player);
-
-                                if (_EnableInputsIpc)
-                                {
-                                    _MMF_Inputs.UpdateComputedPlayerData(Player.ID, Player.RIController.Computed_X, Player.RIController.Computed_Y, Player.RIController.Hid_Buttons);
-                                    
-                                    if (_MMF_Inputs.WriteData() != 0)
-                                        Logger.WriteLog("Succesfully copied P" + Player.ID.ToString() + " data to MMF " + _MMF_Inputs.MemoryFileName);
-                                }
+                                ProcessPlayerComputedInput(Player);
                             }
                         }
                     }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Process the computed player input data and send it to the hooked game.
+        /// </summary>
+        /// <param name="Player"></param>
+        private void ProcessPlayerComputedInput(PlayerSettings Player)
+        {
+            if (_Game == null || !_Game.ProcessHooked)
+                return;
+
+            RawInputController Controller = Player.RIController;
+            if (Controller == null)
+                return;
+
+            if (_EnableInputsIpc)
+                _MMF_Inputs.UpdateRawPlayerData(Player.ID, (UInt32)Player.RIController.Computed_X, (UInt32)Player.RIController.Computed_Y);
+
+            _Game.GetScreenResolution();
+            Logger.WriteLog("PrimaryScreen Size (Px) = [ " + _Game.ScreenWidth + "x" + _Game.ScreenHeight + " ]");
+
+            if (!Controller.IsRelativeCoordinates)
+            {
+                if (Player.RIController.DeviceType == RawInputDeviceType.RIM_TYPEHID && Player.AnalogAxisRangeOverride)
+                {
+                    Logger.WriteLog("Overriding player axis range values : X => [ " + Player.AnalogManual_Xmin.ToString() + ", " + Player.AnalogManual_Xmax.ToString() + " ], Y => [ " + Player.AnalogManual_Ymin.ToString() + ", " + Player.AnalogManual_Ymax.ToString() + " ]");
+                    Player.RIController.Computed_X = _Game.ScreenScale(Player.RIController.Computed_X, Player.AnalogManual_Xmin, Player.AnalogManual_Xmax, 0, _Game.ScreenWidth);
+                    Player.RIController.Computed_Y = _Game.ScreenScale(Player.RIController.Computed_Y, Player.AnalogManual_Ymin, Player.AnalogManual_Ymax, 0, _Game.ScreenHeight);
+                }
+                else
+                {
+                    Player.RIController.Computed_X = _Game.ScreenScale(Player.RIController.Computed_X, Player.RIController.Axis_X_Min, Player.RIController.Axis_X_Max, 0, _Game.ScreenWidth);
+                    Player.RIController.Computed_Y = _Game.ScreenScale(Player.RIController.Computed_Y, Player.RIController.Axis_Y_Min, Player.RIController.Axis_Y_Max, 0, _Game.ScreenHeight);
+                }
+
+                if (Player.InvertAxis_X)
+                    Player.RIController.Computed_X = _Game.ScreenWidth - Player.RIController.Computed_X;
+                if (Player.InvertAxis_Y)
+                    Player.RIController.Computed_Y = _Game.ScreenHeight - Player.RIController.Computed_Y;
+
+                Logger.WriteLog("OnScreen Cursor Position (Px) = [ " + Player.RIController.Computed_X + ", " + Player.RIController.Computed_Y + " ]");
+
+                if (Configurator.GetInstance().Act_Labs_Offset_Enable)
+                {
+                    Player.RIController.Computed_X += Player.Act_Labs_Offset_X;
+                    Player.RIController.Computed_Y += Player.Act_Labs_Offset_Y;
+                    Logger.WriteLog("ActLabs adaptated OnScreen Cursor Position (Px) = [ " + Player.RIController.Computed_X + ", " + Player.RIController.Computed_Y + " ]");
+                }
+            }
+
+            if (_ForceScalingX != 1.0)
+            {
+                Logger.WriteLog("Forcing X Scaling = " + _ForceScalingX.ToString());
+                double HalfScreenSize = (double)_Game.ScreenWidth / 2.0;
+                double NewX = (((double)Player.RIController.Computed_X - HalfScreenSize) * _ForceScalingX) + HalfScreenSize;
+                Player.RIController.Computed_X = Convert.ToInt32(NewX);
+                Logger.WriteLog("Forced scaled OnScreen Cursor Position (Px) = [ " + Player.RIController.Computed_X + ", " + Player.RIController.Computed_Y + " ]");
+            }
+
+            _Game.IsFullscreen = _Game.GetFullscreenStatus();
+            if (!_Game.IsFullscreen)
+            {
+                Logger.WriteLog("ClientWindow Style = Windowed");
+                _Game.GetClientwindowInfo();
+
+                if (!_Game.ClientScale(Player))
+                {
+                    Logger.WriteLog("Error converting screen location to client location");
+                    return;
+                }
+                Logger.WriteLog("ClientWindow Location (px) = [ " + _Game.clientWindowLocation.X.ToString() + ", " + _Game.clientWindowLocation.Y.ToString() + " ]");
+                Logger.WriteLog("ClientWindow Size (px) = [ " + (_Game.WindowRect.Right - _Game.WindowRect.Left).ToString() + "x" + (_Game.WindowRect.Bottom - _Game.WindowRect.Top).ToString() + " ]");
+                Logger.WriteLog("OnClient Cursor Position (Px) = [ " + Player.RIController.Computed_X + ", " + Player.RIController.Computed_Y + " ]");
+
+                if (!_Game.GetClientRect())
+                {
+                    Logger.WriteLog("Error getting client Rect");
+                    return;
+                }
+            }
+            else
+            {
+                Logger.WriteLog("ClientWindow Style = FullScreen");
+                Rect r = new Rect();
+                r.Top = 0;
+                r.Left = 0;
+                r.Bottom = _Game.ScreenHeight;
+                r.Right = _Game.ScreenWidth;
+                _Game.ClientRect = r;
+            }
+
+            if (!_Game.GameScale(Player))
+            {
+                Logger.WriteLog("Error converting client location to game location");
+                return;
+            }
+
+            Logger.WriteLog("Game Position (Hex) = [ " + Player.RIController.Computed_X.ToString("X4") + ", " + Player.RIController.Computed_Y.ToString("X4") + " ]");
+            Logger.WriteLog("Game Position (Dec) = [ " + Player.RIController.Computed_X.ToString() + ", " + Player.RIController.Computed_Y.ToString() + " ]");
+            if (Player.RIController.Computed_Buttons != 0)
+                Logger.WriteLog("Controller Buttons Events : " + Player.RIController.Computed_Buttons.ToString());
+            Logger.WriteLog("-");
+
+            if (!_NoInput)
+                _Game.SendInput(Player);
+
+            if (_EnableInputsIpc)
+            {
+                _MMF_Inputs.UpdateComputedPlayerData(Player.ID, Player.RIController.Computed_X, Player.RIController.Computed_Y, Player.RIController.Hid_Buttons);
+                if (_MMF_Inputs.WriteData() != 0)
+                    Logger.WriteLog("Succesfully copied P" + Player.ID.ToString() + " data to MMF " + _MMF_Inputs.MemoryFileName);
+            }
+        }
+
+        internal void ProcessTcpInputCommand(int PlayerID, int? X, int? Y, bool? Fire, bool? Reload, bool? Action)
+        {
+            if (_Game == null || !_Game.ProcessHooked)
+                return;
+
+            PlayerSettings player = Configurator.GetInstance().GetPlayerSettings(PlayerID);
+            if (player == null || player.Mode != PlayerSettings.PLAYER_MODE_TCPINPUT || player.RIController == null)
+                return;
+
+            lock (_TcpInputSync)
+            {
+                if (X.HasValue)
+                    player.RIController.Computed_X = X.Value;
+                if (Y.HasValue)
+                    player.RIController.Computed_Y = Y.Value;
+
+                RawInputcontrollerButtonEvent buttonEvents = 0;
+
+                if (Fire.HasValue)
+                {
+                    if (Fire.Value && !player.TcpFirePressed)
+                        buttonEvents |= RawInputcontrollerButtonEvent.OnScreenTriggerDown;
+                    else if (!Fire.Value && player.TcpFirePressed)
+                        buttonEvents |= RawInputcontrollerButtonEvent.OnScreenTriggerUp;
+                    player.TcpFirePressed = Fire.Value;
+                }
+
+                if (Reload.HasValue)
+                {
+                    if (Reload.Value && !player.TcpReloadPressed)
+                        buttonEvents |= RawInputcontrollerButtonEvent.OffScreenTriggerDown;
+                    else if (!Reload.Value && player.TcpReloadPressed)
+                        buttonEvents |= RawInputcontrollerButtonEvent.OffScreenTriggerUp;
+                    player.TcpReloadPressed = Reload.Value;
+                }
+
+                if (Action.HasValue)
+                {
+                    if (Action.Value && !player.TcpActionPressed)
+                        buttonEvents |= RawInputcontrollerButtonEvent.ActionDown;
+                    else if (!Action.Value && player.TcpActionPressed)
+                        buttonEvents |= RawInputcontrollerButtonEvent.ActionUp;
+                    player.TcpActionPressed = Action.Value;
+                }
+
+                player.RIController.Computed_Buttons = buttonEvents;
+
+                ProcessPlayerComputedInput(player);
+            }
+        }
+
+        /// <summary>
+        /// Handler for binary DemulShooter protocol data from TCP clients.
+        /// Converts normalized float coordinates and button states to player input events.
+        /// Supports BTN_LEFT (trigger), BTN_RIGHT (reload), and BTN_MIDDLE (action) for 4 players.
+        /// </summary>
+        internal void ProcessTcpInputData(float[] axisX, float[] axisY, bool[] trigger, bool[] reload, bool[] action)
+        {
+            if (_Game == null || !_Game.ProcessHooked)
+                return;
+
+            lock (_TcpInputSync)
+            {
+                for (int playerId = 1; playerId <= 4; playerId++)
+                {
+                    PlayerSettings player = Configurator.GetInstance().GetPlayerSettings(playerId);
+                    if (player == null || player.Mode != PlayerSettings.PLAYER_MODE_TCPINPUT || player.RIController == null)
+                        continue;
+
+                    int idx = playerId - 1;
+
+                    // Convert normalized coordinates (0.0-1.0) to screen coordinates
+                    player.RIController.Computed_X = (int)(axisX[idx] * 0xFFFF);
+                    player.RIController.Computed_Y = (int)(axisY[idx] * 0xFFFF);
+
+                    RawInputcontrollerButtonEvent buttonEvents = 0;
+
+                    // Handle trigger (BTN_LEFT)
+                    bool currentTrigger = trigger[idx];
+                    if (currentTrigger && !player.TcpFirePressed)
+                        buttonEvents |= RawInputcontrollerButtonEvent.OnScreenTriggerDown;
+                    else if (!currentTrigger && player.TcpFirePressed)
+                        buttonEvents |= RawInputcontrollerButtonEvent.OnScreenTriggerUp;
+                    player.TcpFirePressed = currentTrigger;
+                    player.RIController.Hid_Buttons[0] = currentTrigger;
+
+                    // Handle reload (BTN_RIGHT)
+                    bool currentReload = reload[idx];
+                    if (currentReload && !player.TcpReloadPressed)
+                        buttonEvents |= RawInputcontrollerButtonEvent.OffScreenTriggerDown;
+                    else if (!currentReload && player.TcpReloadPressed)
+                        buttonEvents |= RawInputcontrollerButtonEvent.OffScreenTriggerUp;
+                    player.TcpReloadPressed = currentReload;
+                    player.RIController.Hid_Buttons[2] = currentReload;
+
+                    // Handle action (BTN_MIDDLE)
+                    bool currentAction = action[idx];
+                    if (currentAction && !player.TcpActionPressed)
+                        buttonEvents |= RawInputcontrollerButtonEvent.ActionDown;
+                    else if (!currentAction && player.TcpActionPressed)
+                        buttonEvents |= RawInputcontrollerButtonEvent.ActionUp;
+                    player.TcpActionPressed = currentAction;
+                    player.RIController.Hid_Buttons[1] = currentAction;
+
+                    player.RIController.Computed_Buttons = buttonEvents;
+
+                    ProcessPlayerComputedInput(player);
                 }
             }
         }
@@ -1277,6 +1424,11 @@ namespace DemulShooter
             if (_Net_OutputHelper != null)
             {
                 _Net_OutputHelper.Stop();
+            }
+
+            if (_TcpInputServer != null)
+            {
+                _TcpInputServer.Stop();
             }
 
             //Cleanup so that the icon will be removed when the application is closed

--- a/DemulShooter/TcpInputServer.cs
+++ b/DemulShooter/TcpInputServer.cs
@@ -1,0 +1,181 @@
+using System;
+using System.IO;
+using System.Net;
+using System.Net.Sockets;
+using System.Threading;
+using DsCore;
+
+namespace DemulShooter
+{
+    /// <summary>
+    /// TCP Input Server for simplified mouse protocol supporting 4 players.
+    /// Compatible with batocera-wine-guns for BTN_LEFT (trigger), BTN_RIGHT (reload), and BTN_MIDDLE (action).
+    /// Packet format: X[4](float) Y[4](float) EnableInputsHack(byte) HideCrosshairs(byte) Trigger[4](byte) Reload[4](byte) Action[4](byte)
+    /// Total: 46 bytes
+    /// </summary>
+    internal delegate void TcpInputDataHandler(float[] axisX, float[] axisY, bool[] trigger, bool[] reload, bool[] action);
+
+    internal class TcpInputServer
+    {
+        private const int MAX_PLAYERS = 4;
+
+        private readonly TcpInputDataHandler _dataHandler;
+        private readonly int _port;
+        private TcpListener _listener;
+        private Thread _listenerThread;
+        private volatile bool _running;
+
+        public TcpInputServer(TcpInputDataHandler dataHandler, int port)
+        {
+            _dataHandler = dataHandler;
+            _port = port;
+        }
+
+        public void Start()
+        {
+            if (_running)
+                return;
+
+            _running = true;
+            _listenerThread = new Thread(new ThreadStart(ListenerThreadLoop));
+            _listenerThread.IsBackground = true;
+            _listenerThread.Start();
+        }
+
+        public void Stop()
+        {
+            _running = false;
+
+            try
+            {
+                _listener?.Stop();
+            }
+            catch { }
+
+            try
+            {
+                if (_listenerThread != null && _listenerThread.IsAlive)
+                    _listenerThread.Join(1000);
+            }
+            catch { }
+        }
+
+        private void ListenerThreadLoop()
+        {
+            try
+            {
+                _listener = new TcpListener(IPAddress.Loopback, _port);
+                _listener.Server.SetSocketOption(SocketOptionLevel.Tcp, SocketOptionName.NoDelay, 1);
+                _listener.Start();
+                Logger.WriteLog("TcpInputServer listening on 127.0.0.1:" + _port);
+
+                while (_running)
+                {
+                    TcpClient client = null;
+                    try
+                    {
+                        client = _listener.AcceptTcpClient();
+                        Logger.WriteLog("TcpInputServer: client connected " + client.Client.RemoteEndPoint);
+                        HandleClient(client);
+                    }
+                    catch (SocketException ex)
+                    {
+                        if (_running)
+                            Logger.WriteLog("TcpInputServer socket error: " + ex.Message);
+                    }
+                    catch (Exception ex)
+                    {
+                        Logger.WriteLog("TcpInputServer error: " + ex.Message);
+                    }
+                    finally
+                    {
+                        if (client != null)
+                        {
+                            try { client.Close(); } catch { }
+                        }
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                Logger.WriteLog("TcpInputServer failed to start: " + ex.Message);
+            }
+        }
+
+        private void HandleClient(TcpClient client)
+        {
+            // Packet format: X[4](float) Y[4](float) EnableInputsHack(byte) HideCrosshairs(byte) Trigger[4](byte) Reload[4](byte) Action[4](byte) = 46 bytes
+            const int PACKET_SIZE = 46;
+            using (NetworkStream stream = client.GetStream())
+            {
+                byte[] buffer = new byte[PACKET_SIZE * 16];
+                int buffered = 0;
+
+                while (_running && client.Connected)
+                {
+                    int bytesRead = stream.Read(buffer, buffered, buffer.Length - buffered);
+                    if (bytesRead == 0)
+                        break;
+
+                    buffered += bytesRead;
+
+                    int processed = 0;
+                    while (buffered - processed >= PACKET_SIZE)
+                    {
+                        TryParsePacket(buffer, processed);
+                        processed += PACKET_SIZE;
+                    }
+
+                    if (processed > 0)
+                    {
+                        int remaining = buffered - processed;
+                        if (remaining > 0)
+                            Buffer.BlockCopy(buffer, processed, buffer, 0, remaining);
+                        buffered = remaining;
+                    }
+                }
+            }
+        }
+
+        private void TryParsePacket(byte[] buffer, int offset)
+        {
+            try
+            {
+                float[] axisX = new float[4];
+                float[] axisY = new float[4];
+                bool[] trigger = new bool[4];
+                bool[] reload = new bool[4];
+                bool[] action = new bool[4];
+
+                for (int i = 0; i < 4; i++)
+                {
+                    axisX[i] = BitConverter.ToSingle(buffer, offset);
+                    offset += 4;
+                }
+
+                for (int i = 0; i < 4; i++)
+                {
+                    axisY[i] = BitConverter.ToSingle(buffer, offset);
+                    offset += 4;
+                }
+
+                offset += 2; // EnableInputsHack, HideCrosshairs
+
+                for (int i = 0; i < 4; i++)
+                    trigger[i] = buffer[offset++] != 0;
+
+                for (int i = 0; i < 4; i++)
+                    reload[i] = buffer[offset++] != 0;
+
+                for (int i = 0; i < 4; i++)
+                    action[i] = buffer[offset++] != 0;
+
+                _dataHandler?.Invoke(axisX, axisY, trigger, reload, action);
+            }
+            catch (Exception ex)
+            {
+                Logger.WriteLog("TcpInputServer packet parse error: " + ex.Message);
+            }
+        }
+    }
+}

--- a/DemulShooterX64/DemulShooterWindowX64.cs
+++ b/DemulShooterX64/DemulShooterWindowX64.cs
@@ -51,6 +51,10 @@ namespace DemulShooterX64
         private Net_OutputHelper _Net_OutputHelper;
         private Thread _OutputUpdateLoop;
 
+        //TCP Input Server
+        private TcpInputServer _TcpInputServer;
+        private object _TcpInputSync = new object();
+
         //Game options
         private Game _Game;
         private string _Rom = String.Empty;
@@ -193,6 +197,32 @@ namespace DemulShooterX64
                 }
                 else
                     Logger.WriteLog("P" + Player.ID + " Gamepad ID = " + Player.GamepadID);
+            }
+
+            bool tcpInputEnabled = false;
+            foreach (PlayerSettings Player in Configurator.GetInstance().PlayersSettings)
+            {
+                if (Player.Mode == PlayerSettings.PLAYER_MODE_TCPINPUT)
+                {
+                    tcpInputEnabled = true;
+                    if (Player.RIController == null)
+                    {
+                        Player.RIController = new RawInputController();
+                        Player.RIController.SetDeviceName("[TCP Input P" + Player.ID + "]");
+                        Player.RIController.SetDeviceType(RawInputDeviceType.RIM_TYPEHID);
+                        Player.RIController.SetAxisRange(0, 0x0000FFFF, 0, 0x0000FFFF);
+                        Player.RIController.SetComputedCoordinates(0, 0);
+                        Player.RIController.SetComputedButtons(0);
+                    }
+                }
+            }
+
+            if (tcpInputEnabled)
+            {
+                int tcpPort = Configurator.GetInstance().TcpInputPort;
+                Logger.WriteLog("Starting TCP input server on port " + tcpPort);
+                _TcpInputServer = new TcpInputServer(ProcessTcpInputData, tcpPort);
+                _TcpInputServer.Start();
             }
 
             //Setting up IPC for inputs/outputs
@@ -787,6 +817,168 @@ namespace DemulShooterX64
         }
 
         /// <summary>
+        /// Handler for binary DemulShooter protocol data from TCP clients.
+        /// Converts normalized float coordinates (0.0-1.0) and button states to player input events.
+        /// </summary>
+        internal void ProcessTcpInputData(float[] axisX, float[] axisY, bool[] trigger, bool[] reload, bool[] action)
+        {
+            if (_Game == null || !_Game.ProcessHooked)
+                return;
+
+            lock (_TcpInputSync)
+            {
+                for (int playerId = 1; playerId <= 4; playerId++)
+                {
+                    PlayerSettings player = Configurator.GetInstance().GetPlayerSettings(playerId);
+                    if (player == null)
+                        continue;
+
+                    if (player.Mode != PlayerSettings.PLAYER_MODE_TCPINPUT || player.RIController == null)
+                        continue;
+
+                    int idx = playerId - 1;
+
+                    player.RIController.Computed_X = (int)(axisX[idx] * 0xFFFF);
+                    player.RIController.Computed_Y = (int)(axisY[idx] * 0xFFFF);
+
+                    RawInputcontrollerButtonEvent buttonEvents = 0;
+
+                    bool currentTrigger = trigger[idx];
+                    if (currentTrigger && !player.TcpFirePressed)
+                        buttonEvents |= RawInputcontrollerButtonEvent.OnScreenTriggerDown;
+                    else if (!currentTrigger && player.TcpFirePressed)
+                        buttonEvents |= RawInputcontrollerButtonEvent.OnScreenTriggerUp;
+                    player.TcpFirePressed = currentTrigger;
+                    player.RIController.Hid_Buttons[0] = currentTrigger;
+
+                    bool currentReload = reload[idx];
+                    if (currentReload && !player.TcpReloadPressed)
+                        buttonEvents |= RawInputcontrollerButtonEvent.OffScreenTriggerDown;
+                    else if (!currentReload && player.TcpReloadPressed)
+                        buttonEvents |= RawInputcontrollerButtonEvent.OffScreenTriggerUp;
+                    player.TcpReloadPressed = currentReload;
+                    player.RIController.Hid_Buttons[2] = currentReload;
+
+                    bool currentAction = action[idx];
+                    if (currentAction && !player.TcpActionPressed)
+                        buttonEvents |= RawInputcontrollerButtonEvent.ActionDown;
+                    else if (!currentAction && player.TcpActionPressed)
+                        buttonEvents |= RawInputcontrollerButtonEvent.ActionUp;
+                    player.TcpActionPressed = currentAction;
+                    player.RIController.Hid_Buttons[1] = currentAction;
+
+                    player.RIController.Computed_Buttons = buttonEvents;
+
+                    ProcessPlayerComputedInput(player);
+                }
+            }
+        }
+
+        private void ProcessPlayerComputedInput(PlayerSettings Player)
+        {
+            if (_Game == null || !_Game.ProcessHooked)
+                return;
+
+            RawInputController Controller = Player.RIController;
+            if (Controller == null)
+                return;
+
+            if (_EnableInputsIpc)
+                _MMF_Inputs.UpdateRawPlayerData(Player.ID, (UInt32)Player.RIController.Computed_X, (UInt32)Player.RIController.Computed_Y);
+
+            _Game.GetScreenResolution();
+            Logger.WriteLog("PrimaryScreen Size (Px) = [ " + _Game.ScreenWidth + "x" + _Game.ScreenHeight + " ]");
+
+            if (!Controller.IsRelativeCoordinates)
+            {
+                if (Player.RIController.DeviceType == RawInputDeviceType.RIM_TYPEHID && Player.AnalogAxisRangeOverride)
+                {
+                    Player.RIController.Computed_X = _Game.ScreenScale(Player.RIController.Computed_X, Player.AnalogManual_Xmin, Player.AnalogManual_Xmax, 0, _Game.ScreenWidth);
+                    Player.RIController.Computed_Y = _Game.ScreenScale(Player.RIController.Computed_Y, Player.AnalogManual_Ymin, Player.AnalogManual_Ymax, 0, _Game.ScreenHeight);
+                }
+                else
+                {
+                    Player.RIController.Computed_X = _Game.ScreenScale(Player.RIController.Computed_X, Player.RIController.Axis_X_Min, Player.RIController.Axis_X_Max, 0, _Game.ScreenWidth);
+                    Player.RIController.Computed_Y = _Game.ScreenScale(Player.RIController.Computed_Y, Player.RIController.Axis_Y_Min, Player.RIController.Axis_Y_Max, 0, _Game.ScreenHeight);
+                }
+
+                if (Player.InvertAxis_X)
+                    Player.RIController.Computed_X = _Game.ScreenWidth - Player.RIController.Computed_X;
+                if (Player.InvertAxis_Y)
+                    Player.RIController.Computed_Y = _Game.ScreenHeight - Player.RIController.Computed_Y;
+
+                Logger.WriteLog("OnScreen Cursor Position (Px) = [ " + Player.RIController.Computed_X + ", " + Player.RIController.Computed_Y + " ]");
+
+                if (Configurator.GetInstance().Act_Labs_Offset_Enable)
+                {
+                    Player.RIController.Computed_X += Player.Act_Labs_Offset_X;
+                    Player.RIController.Computed_Y += Player.Act_Labs_Offset_Y;
+                    Logger.WriteLog("ActLabs adaptated OnScreen Cursor Position (Px) = [ " + Player.RIController.Computed_X + ", " + Player.RIController.Computed_Y + " ]");
+                }
+            }
+
+            if (_ForceScalingX != 1.0)
+            {
+                double HalfScreenSize = (double)_Game.ScreenWidth / 2.0;
+                double NewX = (((double)Player.RIController.Computed_X - HalfScreenSize) * _ForceScalingX) + HalfScreenSize;
+                Player.RIController.Computed_X = Convert.ToInt32(NewX);
+                Logger.WriteLog("Forced scaled OnScreen Cursor Position (Px) = [ " + Player.RIController.Computed_X + ", " + Player.RIController.Computed_Y + " ]");
+            }
+
+            _Game.IsFullscreen = _Game.GetFullscreenStatus();
+            if (!_Game.IsFullscreen)
+            {
+                Logger.WriteLog("ClientWindow Style = Windowed");
+                _Game.GetClientwindowInfo();
+
+                if (!_Game.ClientScale(Player))
+                {
+                    Logger.WriteLog("Error converting screen location to client location");
+                    return;
+                }
+                Logger.WriteLog("OnClient Cursor Position (Px) = [ " + Player.RIController.Computed_X + ", " + Player.RIController.Computed_Y + " ]");
+
+                if (!_Game.GetClientRect())
+                {
+                    Logger.WriteLog("Error getting client Rect");
+                    return;
+                }
+            }
+            else
+            {
+                Logger.WriteLog("ClientWindow Style = FullScreen");
+                Rect r = new Rect();
+                r.Top = 0;
+                r.Left = 0;
+                r.Bottom = _Game.ScreenHeight;
+                r.Right = _Game.ScreenWidth;
+                _Game.ClientRect = r;
+            }
+
+            if (!_Game.GameScale(Player))
+            {
+                Logger.WriteLog("Error converting client location to game location");
+                return;
+            }
+
+            Logger.WriteLog("Game Position (Hex) = [ " + Player.RIController.Computed_X.ToString("X4") + ", " + Player.RIController.Computed_Y.ToString("X4") + " ]");
+            Logger.WriteLog("Game Position (Dec) = [ " + Player.RIController.Computed_X.ToString() + ", " + Player.RIController.Computed_Y.ToString() + " ]");
+            if (Player.RIController.Computed_Buttons != 0)
+                Logger.WriteLog("Controller Buttons Events : " + Player.RIController.Computed_Buttons.ToString());
+            Logger.WriteLog("-");
+
+            if (!_NoInput)
+                _Game.SendInput(Player);
+
+            if (_EnableInputsIpc)
+            {
+                _MMF_Inputs.UpdateComputedPlayerData(Player.ID, Player.RIController.Computed_X, Player.RIController.Computed_Y, Player.RIController.Hid_Buttons);
+                if (_MMF_Inputs.WriteData() != 0)
+                    Logger.WriteLog("Succesfully copied P" + Player.ID.ToString() + " data to MMF " + _MMF_Inputs.MemoryFileName);
+            }
+        }
+
+        /// <summary>
         /// Output handling thread :
         /// This infinite loop will check the targeted game values and send them to registerd Output clients
         /// </summary>
@@ -893,6 +1085,11 @@ namespace DemulShooterX64
             if (_Net_OutputHelper != null)
             {
                 _Net_OutputHelper.Stop();
+            }
+
+            if (_TcpInputServer != null)
+            {
+                _TcpInputServer.Stop();
             }
 
             //Cleanup so that the icon will be removed when the application is closed

--- a/DemulShooterX64/DemulShooterX64.csproj
+++ b/DemulShooterX64/DemulShooterX64.csproj
@@ -72,6 +72,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="DemulShooterWindowX64.cs" />
+    <Compile Include="TcpInputServer.cs" />
     <Compile Include="Games\Game_ArcadepcDinoInvasion.cs" />
     <Compile Include="Games\Game_ArcadepcDrakon.cs" />
     <Compile Include="Games\Game_ArcadepcMarsSortie.cs" />

--- a/DemulShooterX64/TcpInputServer.cs
+++ b/DemulShooterX64/TcpInputServer.cs
@@ -1,0 +1,174 @@
+using System;
+using System.Net;
+using System.Net.Sockets;
+using System.Threading;
+using DsCore;
+
+namespace DemulShooterX64
+{
+    internal delegate void TcpInputDataHandler(float[] axisX, float[] axisY, bool[] trigger, bool[] reload, bool[] action);
+
+    internal class TcpInputServer
+    {
+        private const int MAX_PLAYERS = 4;
+
+        private readonly TcpInputDataHandler _dataHandler;
+        private readonly int _port;
+        private TcpListener _listener;
+        private Thread _listenerThread;
+        private volatile bool _running;
+
+        public TcpInputServer(TcpInputDataHandler dataHandler, int port)
+        {
+            _dataHandler = dataHandler;
+            _port = port;
+        }
+
+        public void Start()
+        {
+            if (_running)
+                return;
+
+            _running = true;
+            _listenerThread = new Thread(new ThreadStart(ListenerThreadLoop));
+            _listenerThread.IsBackground = true;
+            _listenerThread.Start();
+        }
+
+        public void Stop()
+        {
+            _running = false;
+
+            try
+            {
+                _listener?.Stop();
+            }
+            catch { }
+
+            try
+            {
+                if (_listenerThread != null && _listenerThread.IsAlive)
+                    _listenerThread.Join(1000);
+            }
+            catch { }
+        }
+
+        private void ListenerThreadLoop()
+        {
+            try
+            {
+                _listener = new TcpListener(IPAddress.Loopback, _port);
+                _listener.Server.SetSocketOption(SocketOptionLevel.Tcp, SocketOptionName.NoDelay, 1);
+                _listener.Start();
+                Logger.WriteLog("TcpInputServer listening on 127.0.0.1:" + _port);
+
+                while (_running)
+                {
+                    TcpClient client = null;
+                    try
+                    {
+                        client = _listener.AcceptTcpClient();
+                        Logger.WriteLog("TcpInputServer: client connected " + client.Client.RemoteEndPoint);
+                        HandleClient(client);
+                    }
+                    catch (SocketException ex)
+                    {
+                        if (_running)
+                            Logger.WriteLog("TcpInputServer socket error: " + ex.Message);
+                    }
+                    catch (Exception ex)
+                    {
+                        Logger.WriteLog("TcpInputServer error: " + ex.Message);
+                    }
+                    finally
+                    {
+                        if (client != null)
+                        {
+                            try { client.Close(); } catch { }
+                        }
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                Logger.WriteLog("TcpInputServer failed to start: " + ex.Message);
+            }
+        }
+
+        private void HandleClient(TcpClient client)
+        {
+            // Packet format: X[4](float) Y[4](float) EnableInputsHack(byte) HideCrosshairs(byte) Trigger[4](byte) Reload[4](byte) Action[4](byte) = 46 bytes
+            const int PACKET_SIZE = 46;
+            using (NetworkStream stream = client.GetStream())
+            {
+                byte[] buffer = new byte[PACKET_SIZE * 16];
+                int buffered = 0;
+
+                while (_running && client.Connected)
+                {
+                    int bytesRead = stream.Read(buffer, buffered, buffer.Length - buffered);
+                    if (bytesRead == 0)
+                        break;
+
+                    buffered += bytesRead;
+
+                    int processed = 0;
+                    while (buffered - processed >= PACKET_SIZE)
+                    {
+                        TryParsePacket(buffer, processed);
+                        processed += PACKET_SIZE;
+                    }
+
+                    if (processed > 0)
+                    {
+                        int remaining = buffered - processed;
+                        if (remaining > 0)
+                            System.Buffer.BlockCopy(buffer, processed, buffer, 0, remaining);
+                        buffered = remaining;
+                    }
+                }
+            }
+        }
+
+        private void TryParsePacket(byte[] buffer, int offset)
+        {
+            try
+            {
+                float[] axisX = new float[MAX_PLAYERS];
+                float[] axisY = new float[MAX_PLAYERS];
+                bool[] trigger = new bool[MAX_PLAYERS];
+                bool[] reload = new bool[MAX_PLAYERS];
+                bool[] action = new bool[MAX_PLAYERS];
+
+                for (int i = 0; i < MAX_PLAYERS; i++)
+                {
+                    axisX[i] = BitConverter.ToSingle(buffer, offset);
+                    offset += 4;
+                }
+
+                for (int i = 0; i < MAX_PLAYERS; i++)
+                {
+                    axisY[i] = BitConverter.ToSingle(buffer, offset);
+                    offset += 4;
+                }
+
+                offset += 2; // EnableInputsHack, HideCrosshairs
+
+                for (int i = 0; i < MAX_PLAYERS; i++)
+                    trigger[i] = buffer[offset++] != 0;
+
+                for (int i = 0; i < MAX_PLAYERS; i++)
+                    reload[i] = buffer[offset++] != 0;
+
+                for (int i = 0; i < MAX_PLAYERS; i++)
+                    action[i] = buffer[offset++] != 0;
+
+                _dataHandler?.Invoke(axisX, axisY, trigger, reload, action);
+            }
+            catch (Exception ex)
+            {
+                Logger.WriteLog("TcpInputServer packet parse error: " + ex.Message);
+            }
+        }
+    }
+}

--- a/DsCore/Config/Configurator.cs
+++ b/DsCore/Config/Configurator.cs
@@ -414,6 +414,7 @@ namespace DsCore.Config
         private bool _OutputEnabled = false;
         private bool _Wm_OutputEnabled = true;
         private bool _Net_OutputEnabled = false;
+        private int _TcpInputPort = 33610;
         private int _OutputPollingDelay = 1;
         private int _OutputCustomDamagedDelay = 200;
         private int _OutputCustomRecoilOnDelay = 10;
@@ -433,6 +434,10 @@ namespace DsCore.Config
         {
             get { return _Net_OutputEnabled; }
             set { _Net_OutputEnabled = value; }
+        }
+        public int TcpInputPort
+        {
+            get { return _TcpInputPort; }
         }
         public int OutputPollingDelay
         {
@@ -604,6 +609,11 @@ namespace DsCore.Config
                                         _DIK_Dolphin_P2_MClick = (HardwareScanCode)Enum.Parse(typeof(HardwareScanCode), StrValue);
                                     }
                                     catch { Logger.WriteLog("Error parsing " + StrKey + " value in INI file : " + StrValue + " is not valid"); }
+                                }
+                                else if (StrKey.ToLower().Equals("tcpinputport"))
+                                {
+                                    if (!int.TryParse(StrValue, out _TcpInputPort))
+                                        Logger.WriteLog("Error parsing " + StrKey + " value in INI file : " + StrValue + " is not valid");
                                 }
                                 else if (StrKey.ToLower().Equals("dolphin_p2_rclick"))
                                 {

--- a/DsCore/Config/PlayerSettings.cs
+++ b/DsCore/Config/PlayerSettings.cs
@@ -15,6 +15,7 @@ namespace DsCore.Config
     {
         public const string PLAYER_MODE_RAWINPUT = "RAWINPUT";
         public const string PLAYER_MODE_XINPUT = "XINPUT";
+        public const string PLAYER_MODE_TCPINPUT = "TCPINPUT";
 
         // General Data
         private int _ID = 0;
@@ -44,6 +45,10 @@ namespace DsCore.Config
         private int _HidButton_OnScreenTrigger = 1;
         private int _HidButton_OffScreenTrigger = 2;
         private int _HidButton_Action = 3;
+
+        private bool _TcpFirePressed = false;
+        private bool _TcpReloadPressed = false;
+        private bool _TcpActionPressed = false;
         #region Accessors
         public RawInputController RIController
         {
@@ -94,6 +99,24 @@ namespace DsCore.Config
         public int HidButton_Action
         {
             get { return _HidButton_Action; }
+        }
+
+        public bool TcpFirePressed
+        {
+            get { return _TcpFirePressed; }
+            set { _TcpFirePressed = value; }
+        }
+
+        public bool TcpReloadPressed
+        {
+            get { return _TcpReloadPressed; }
+            set { _TcpReloadPressed = value; }
+        }
+
+        public bool TcpActionPressed
+        {
+            get { return _TcpActionPressed; }
+            set { _TcpActionPressed = value; }
         }
         #endregion
 

--- a/DsCore/RawInput/RawInputController.cs
+++ b/DsCore/RawInput/RawInputController.cs
@@ -274,6 +274,32 @@ namespace DsCore.RawInput
         #endregion
 
         /// <summary>
+        /// Constructor, build a dummy controller for inputs that are not coming from a physical RawInput device.
+        /// This is used for TCP input where computed axis and button state are driven by an external client.
+        /// </summary>
+        public RawInputController()
+        {
+            _hDevice = IntPtr.Zero;
+            _dwType = RawInputDeviceType.RIM_TYPEHID;
+            _DeviceName = "[TCP Input]";
+            _ManufacturerName = "[TCP Input]";
+            _ProductName = "[TCP Input]";
+            _pPreparsedData = IntPtr.Zero;
+            _Hid_NumberofButtons = 3;
+            _Hid_Buttons = new bool[_Hid_NumberofButtons];
+            _Hid_Axis_List = new List<ushort>() { 0x30, 0x31 };
+            _Hid_Axis_X_Min = 0;
+            _Hid_Axis_X_Max = 0x0000FFFF;
+            _Hid_Axis_Y_Min = 0;
+            _Hid_Axis_Y_Max = 0x0000FFFF;
+            _ControllerData.Axis.X = 0;
+            _ControllerData.Axis.Y = 0;
+            _ControllerData.Buttons = 0;
+            _Selected_HidAxisX = 0x30;
+            _Selected_HidAxisY = 0x31;
+        }
+
+        /// <summary>
         /// Constructor, fill as much Hidp_Struct as we can at the creation
         /// </summary>
         /// <param name="DeviceHandle">A handle to the raw input device.</param>
@@ -553,6 +579,35 @@ namespace DsCore.RawInput
         {
             if (_Hid_Buttons.Length > ButtonNumber)
                 _Hid_Buttons[ButtonNumber] = ButtonState;
+        }
+
+        public void SetComputedCoordinates(int X, int Y)
+        {
+            _ControllerData.Axis.X = X;
+            _ControllerData.Axis.Y = Y;
+        }
+
+        public void SetComputedButtons(RawInputcontrollerButtonEvent Buttons)
+        {
+            _ControllerData.Buttons = Buttons;
+        }
+
+        public void SetAxisRange(int XMin, int XMax, int YMin, int YMax)
+        {
+            _Hid_Axis_X_Min = XMin;
+            _Hid_Axis_X_Max = XMax;
+            _Hid_Axis_Y_Min = YMin;
+            _Hid_Axis_Y_Max = YMax;
+        }
+
+        public void SetDeviceName(string DeviceName)
+        {
+            _DeviceName = DeviceName;
+        }
+
+        public void SetDeviceType(RawInputDeviceType DeviceType)
+        {
+            _dwType = DeviceType;
         }
 
         /// <summary>

--- a/tcp_mouse_client.py
+++ b/tcp_mouse_client.py
@@ -1,0 +1,472 @@
+#!/usr/bin/env python3
+"""TCP input client for DemulShooter and BepInEx gun game plugins.
+
+Device type (gun vs mouse) is auto-detected: absolute-axis devices are treated
+as light guns (GunState), relative-axis devices as mice (MouseState).
+Offscreen reload: when a gun aims outside the screen and fires, trigger is
+converted to reload automatically.
+
+Button remapping: extra gun buttons can be forwarded as keyboard keys via a
+UInput virtual device, independently of the DS bridge state.
+
+Supported games: demul, rha, wws, tra, owr, mib, mia, nha2, marss, pvz, pbx, rgs
+
+Examples:
+  %(prog)s --game demul --gun1 /dev/input/event0
+  %(prog)s --game wws --gun1 /dev/input/event0 --gun2 /dev/input/event1
+  %(prog)s --game tra --width 1280 --height 1024 \\
+           --gun1 /dev/input/event2 --gun2 /dev/input/event3
+"""
+
+import argparse
+import glob
+import re
+import select
+import signal
+import socket
+import struct
+import subprocess
+import sys
+import time
+
+try:
+    from evdev import InputDevice, UInput, ecodes
+except ImportError:
+    print("Missing dependency: python-evdev. Install with `pip install evdev`.")
+    sys.exit(1)
+
+DEFAULT_HOST = "127.0.0.1"
+DEFAULT_PORT = 33610
+DEFAULT_SCREEN_WIDTH = 1920
+DEFAULT_SCREEN_HEIGHT = 1080
+
+RECONNECT_INTERVAL = 2.0
+
+# Per-player button → key mappings (Start and Coin differ per player slot)
+PLAYER_MAPPING = [
+    {"BTN_MIDDLE": "KEY_1", "BTN_1": "KEY_5"},   # P1: Start=1, Coin=5
+    {"BTN_MIDDLE": "KEY_2", "BTN_1": "KEY_6"},   # P2: Start=2, Coin=6
+    {"BTN_MIDDLE": "KEY_3", "BTN_1": "KEY_7"},   # P3: Start=3, Coin=7
+    {"BTN_MIDDLE": "KEY_4", "BTN_1": "KEY_8"},   # P4: Start=4, Coin=8
+]
+
+# Shared mappings applied to all players (None = pass through unmapped)
+SHARED_MAPPING = {
+    "BTN_2": None,
+    "BTN_3": None,
+    "BTN_4": None,
+    "BTN_5": "KEY_UP",
+    "BTN_6": "KEY_DOWN",
+    "BTN_7": "KEY_LEFT",
+    "BTN_8": "KEY_RIGHT",
+}
+
+
+# ─── Screen size detection ────────────────────────────────────────────────────
+
+def get_screen_size():
+    # xrandr: Xorg and XWayland — parses "1920x1080+0+0" on connected output lines
+    try:
+        out = subprocess.check_output(
+            ['xrandr', '--current'], text=True, stderr=subprocess.DEVNULL, timeout=2)
+        m = re.search(r'(\d+)x(\d+)\+\d+\+\d+', out)
+        if m:
+            return int(m.group(1)), int(m.group(2))
+    except Exception:
+        pass
+
+    # wlr-randr: native Wayland (wlroots compositors) — "1920x1080 px, ... (current)"
+    try:
+        out = subprocess.check_output(
+            ['wlr-randr'], text=True, stderr=subprocess.DEVNULL, timeout=2)
+        m = re.search(r'(\d+)x(\d+) px[^\n]*current', out)
+        if m:
+            return int(m.group(1)), int(m.group(2))
+    except Exception:
+        pass
+
+    # DRM sysfs: kernel-level current mode, works without any display server
+    for path in sorted(glob.glob('/sys/class/drm/card*-*/mode')):
+        try:
+            with open(path) as f:
+                m = re.match(r'(\d+)x(\d+)', f.read().strip())
+            if m:
+                return int(m.group(1)), int(m.group(2))
+        except Exception:
+            pass
+
+    return DEFAULT_SCREEN_WIDTH, DEFAULT_SCREEN_HEIGHT
+
+
+# ─── Gun state (absolute-position devices) ───────────────────────────────────
+
+class GunState:
+    def __init__(self, x_min=0, x_max=65535, y_min=0, y_max=65535):
+        self.x = 0
+        self.y = 0
+        self.x_min = x_min
+        self.x_max = x_max
+        self.y_min = y_min
+        self.y_max = y_max
+        self.trigger = 0
+        self.reload = 0
+        self.action = 0
+
+    def is_offscreen(self):
+        if self.x_max > self.x_min:
+            nx = (self.x - self.x_min) / (self.x_max - self.x_min)
+            if nx <= 0.0 or nx >= 1.0:
+                return True
+        if self.y_max > self.y_min:
+            ny = (self.y - self.y_min) / (self.y_max - self.y_min)
+            if ny <= 0.0 or ny >= 1.0:
+                return True
+        return False
+
+    def pixel_x(self, screen_w):
+        if self.x_max <= self.x_min:
+            return 0.0
+        n = (self.x - self.x_min) / (self.x_max - self.x_min)
+        return max(0.0, min(1.0, n)) * screen_w
+
+    def pixel_y(self, screen_h):
+        if self.y_max <= self.y_min:
+            return 0.0
+        n = (self.y - self.y_min) / (self.y_max - self.y_min)
+        return max(0.0, min(1.0, n)) * screen_h
+
+
+# ─── Mouse state (relative-position devices) ─────────────────────────────────
+
+class MouseState:
+    def __init__(self, screen_w=1920, screen_h=1080):
+        self.px = float(screen_w // 2)
+        self.py = float(screen_h // 2)
+        self.screen_w = screen_w
+        self.screen_h = screen_h
+        self.trigger = 0
+        self.reload = 0
+        self.action = 0
+
+    def is_offscreen(self):
+        return False
+
+    def move(self, dx, dy):
+        self.px = max(0.0, min(float(self.screen_w), self.px + dx))
+        self.py = max(0.0, min(float(self.screen_h), self.py + dy))
+
+    def pixel_x(self, *_):
+        return self.px
+
+    def pixel_y(self, *_):
+        return self.py
+
+
+# ─── Packet builders ──────────────────────────────────────────────────────────
+
+def build_ds_packet(states, game, scr_w, scr_h):
+    ax = [s.pixel_x(scr_w) for s in states]
+    ay = [scr_h - s.pixel_y(scr_h) for s in states]
+    offscreen = [s.is_offscreen() and bool(s.trigger) for s in states]
+    t = [0 if of else s.trigger for s, of in zip(states, offscreen)]
+    r = [1 if (s.reload or of) else 0 for s, of in zip(states, offscreen)]
+    a = [s.action for s in states]
+
+    while len(ax) < 4:
+        ax.append(0.0); ay.append(0.0); t.append(0); r.append(0); a.append(0)
+
+    if game == 'rha':
+        # 4P: Axis_X[4] Axis_Y[4] EnableInputsHack HideCrosshairs Trigger[4] = 38
+        return struct.pack('<ffffffff BB BBBB', *ax[:4], *ay[:4], 1, 0, *t[:4])
+    elif game == 'wws':
+        # 2P: Axis_X[2] Axis_Y[2] EnableInputsHack HideCrosshairs Reload[2] Trigger[2] = 22
+        return struct.pack('<ffff BB BB BB', *ax[:2], *ay[:2], 1, 0, *r[:2], *t[:2])
+    elif game == 'tra':
+        # 4P: Axis_X[4] Axis_Y[4] EnableInputsHack HideCrosshairs Reload[4] Trigger[4] = 42
+        return struct.pack('<ffffffff BB BBBB BBBB', *ax[:4], *ay[:4], 1, 0, *r[:4], *t[:4])
+    elif game == 'owr':
+        # 2P: Axis_X[2] Axis_Y[2] ChangeWeapon[2] EnableInputsHack HideCrosshairs Reload[2] Trigger[2] = 24
+        return struct.pack('<ffff BB BB BB BB', *ax[:2], *ay[:2], *a[:2], 1, 0, *r[:2], *t[:2])
+    elif game == 'mib':
+        # 2P: Axis_X[2] Axis_Y[2] EnableInputsHack HideCrosshairs HideGuns Trigger[2] = 21
+        return struct.pack('<ffff BBB BB', *ax[:2], *ay[:2], 1, 0, 0, *t[:2])
+    elif game == 'mia':
+        # 2P: Axis_X[2] Axis_Y[2] EnableInputsHack HideCrosshairs Reload[2] TriggerL[2] TriggerR[2] = 24
+        return struct.pack('<ffff BB BB BB BB', *ax[:2], *ay[:2], 1, 0, *r[:2], *t[:2], 0, 0)
+    elif game == 'nha2':
+        # 2P: Action[2] Axis_X[2] Axis_Y[2] ChangeWeapon[2] EnableInputsHack HideCrosshairs HideGuns Trigger[2] = 25
+        return struct.pack('<BB ffff BB BBB BB', *a[:2], *ax[:2], *ay[:2], *r[:2], 1, 0, 0, *t[:2])
+    elif game == 'marss':
+        # 4P: Axis_X[4] Axis_Y[4] ChangeWeapon[4] EnableInputsHack HideCrosshairs Trigger[4] = 42
+        return struct.pack('<ffffffff BBBB BB BBBB', *ax[:4], *ay[:4], *r[:4], 1, 0, *t[:4])
+    elif game == 'pvz':
+        # 1P: Axis_X[1] Axis_Y[1] EnableInputsHack HideCrosshairs Trigger[1] = 11
+        return struct.pack('<ff BB B', ax[0], ay[0], 1, 0, t[0])
+    elif game == 'demul':
+        # 4P: Axis_X[4] Axis_Y[4] EnableInputsHack HideCrosshairs Trigger[4] Reload[4] Action[4] = 46 bytes
+        # Normalize to 0.0-1.0 (DemulShooter TCP server handles its own coordinate system)
+        dx = [x / scr_w for x in ax]
+        dy = [(scr_h - y) / scr_h for y in ay]
+        return struct.pack('<ffffffff BB BBBB BBBB BBBB',
+                           *dx[:4], *dy[:4], 1, 0, *t[:4], *r[:4], *a[:4])
+    else:
+        # pbx / rgs (default): PBX, DRK, RTNA — 2P = 20 bytes
+        return struct.pack('<ffff BB BB', *ax[:2], *ay[:2], 1, 0, *t[:2])
+
+
+# ─── Device helpers ───────────────────────────────────────────────────────────
+
+def build_mapping(player_num):
+    """Merge SHARED_MAPPING and PLAYER_MAPPING for a player and resolve to ecodes."""
+    raw = dict(SHARED_MAPPING)
+    if player_num - 1 < len(PLAYER_MAPPING):
+        raw.update(PLAYER_MAPPING[player_num - 1])
+    result = {}
+    for src_name, dst_name in raw.items():
+        if dst_name is None:
+            continue
+        src_code = ecodes.ecodes.get(src_name)
+        dst_code = ecodes.ecodes.get(dst_name)
+        if src_code is not None and dst_code is not None:
+            result[src_code] = dst_code
+    return result
+
+
+def open_player(path, player_num, screen_w, screen_h, mapping=None):
+    dev = InputDevice(path)
+    caps = dev.capabilities(verbose=False)
+    abs_codes = [c[0] if isinstance(c, tuple) else c for c in caps.get(ecodes.EV_ABS, [])]
+
+    if ecodes.ABS_X in abs_codes and ecodes.ABS_Y in abs_codes:
+        state = GunState()
+        try:
+            info = dev.absinfo(ecodes.ABS_X)
+            state.x_min, state.x_max = info.min, info.max
+        except Exception:
+            pass
+        try:
+            info = dev.absinfo(ecodes.ABS_Y)
+            state.y_min, state.y_max = info.min, info.max
+        except Exception:
+            pass
+        is_mouse = False
+        kind = "gun"
+    else:
+        state = MouseState(screen_w=screen_w, screen_h=screen_h)
+        is_mouse = True
+        kind = "mouse"
+
+    mapping = mapping or {}
+    uinput = None
+    if mapping:
+        uinput = UInput({ecodes.EV_KEY: list(set(mapping.values()))},
+                        name=f"Gun Keys P{player_num}")
+
+    try:
+        dev.grab()
+    except Exception as e:
+        print(f"Warning: could not grab {path}: {e}", file=sys.stderr)
+
+    suffix = f" [{len(mapping)} remaps]" if mapping else ""
+    print(f"P{player_num}: {kind} {path} ({dev.name}){suffix}")
+    return {"dev": dev, "state": state, "is_mouse": is_mouse, "player": player_num,
+            "mapping": mapping, "uinput": uinput}
+
+
+def apply_mapping(player, event):
+    """Forward a mapped button event to the player's UInput virtual keyboard."""
+    ui = player.get("uinput")
+    if not ui or event.type != ecodes.EV_KEY:
+        return
+    dst = player["mapping"].get(event.code)
+    if dst is None:
+        return
+    try:
+        ui.write(ecodes.EV_KEY, dst, event.value)
+        ui.syn()
+    except Exception as e:
+        print(f"P{player['player']} UInput write error: {e}", file=sys.stderr)
+
+
+def process_event(player, event):
+    """Update player state from one evdev event. Returns True on EV_SYN."""
+    if event.type == ecodes.EV_SYN:
+        return True
+
+    st = player["state"]
+
+    if player["is_mouse"]:
+        if event.type == ecodes.EV_REL:
+            if event.code == ecodes.REL_X:
+                st.move(event.value, 0)
+            elif event.code == ecodes.REL_Y:
+                st.move(0, event.value)
+        elif event.type == ecodes.EV_KEY:
+            if event.code == ecodes.BTN_LEFT:
+                st.trigger = 1 if event.value else 0
+            elif event.code == ecodes.BTN_RIGHT:
+                st.reload = 1 if event.value else 0
+            elif event.code == ecodes.BTN_MIDDLE:
+                st.action = 1 if event.value else 0
+    else:
+        if event.type == ecodes.EV_ABS:
+            if event.code == ecodes.ABS_X:
+                st.x = event.value
+            elif event.code == ecodes.ABS_Y:
+                st.y = event.value
+        elif event.type == ecodes.EV_KEY:
+            if event.code == ecodes.BTN_LEFT:
+                st.trigger = 1 if event.value else 0
+            elif event.code == ecodes.BTN_RIGHT:
+                st.reload = 1 if event.value else 0
+            elif event.code == ecodes.BTN_MIDDLE:
+                st.action = 1 if event.value else 0
+
+    return False
+
+
+# ─── Main ─────────────────────────────────────────────────────────────────────
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="TCP input client for DemulShooter and BepInEx gun game plugins.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+    parser.add_argument("--host", default=DEFAULT_HOST, help="TCP server host (default: 127.0.0.1)")
+    parser.add_argument("--port", type=int, default=DEFAULT_PORT, help="TCP server port (default: 9999)")
+    parser.add_argument("--width", type=int, default=None, help="Screen width (auto-detected if omitted)")
+    parser.add_argument("--height", type=int, default=None, help="Screen height (auto-detected if omitted)")
+    parser.add_argument("--game", default="demul", metavar="GAME",
+                        choices=["demul", "rha", "wws", "tra", "owr", "mib", "mia",
+                                 "nha2", "marss", "pvz", "pbx", "rgs"],
+                        help="Game/engine packet format (default: demul)")
+    parser.add_argument("--gun1", metavar="PATH", help="evdev device for player 1")
+    parser.add_argument("--gun2", metavar="PATH", help="evdev device for player 2")
+    parser.add_argument("--gun3", metavar="PATH", help="evdev device for player 3")
+    parser.add_argument("--gun4", metavar="PATH", help="evdev device for player 4")
+    args = parser.parse_args()
+
+    gun_paths = [(i + 1, p) for i, p in
+                 enumerate([args.gun1, args.gun2, args.gun3, args.gun4]) if p]
+
+    if not gun_paths:
+        parser.error("Specify at least one device via --gun1 / --gun2 / --gun3 / --gun4")
+
+    if args.width and args.height:
+        screen_w, screen_h = args.width, args.height
+    else:
+        screen_w, screen_h = get_screen_size()
+        if args.width:
+            screen_w = args.width
+        if args.height:
+            screen_h = args.height
+        print(f"Auto-detected screen: {screen_w}x{screen_h}")
+
+    players = []
+    for player_num, path in gun_paths:
+        mapping = build_mapping(player_num)
+        try:
+            players.append(open_player(path, player_num, screen_w, screen_h, mapping=mapping))
+        except Exception as e:
+            print(f"Cannot open {path}: {e}", file=sys.stderr)
+            sys.exit(1)
+
+    print(f"Game: {args.game} | Screen: {screen_w}x{screen_h} | Server: {args.host}:{args.port}")
+
+    sock = None
+    last_connect_attempt = 0.0
+    running = True
+
+    def stop(sig, frame):
+        nonlocal running
+        running = False
+
+    signal.signal(signal.SIGTERM, stop)
+    signal.signal(signal.SIGINT, stop)
+
+    try:
+        while running:
+            if sock is None:
+                now = time.monotonic()
+                if now - last_connect_attempt >= RECONNECT_INTERVAL:
+                    last_connect_attempt = now
+                    try:
+                        sock = socket.create_connection((args.host, args.port), timeout=1)
+                        sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
+                        print(f"Connected to {args.host}:{args.port}")
+                    except Exception as e:
+                        print(f"Connection failed: {e}")
+                        sock = None
+
+            fds = [p["dev"].fd for p in players]
+            if sock is not None:
+                fds.append(sock.fileno())
+
+            try:
+                readable, _, _ = select.select(fds, [], [], 0.05)
+            except Exception:
+                continue
+
+            if sock is not None and sock.fileno() in readable:
+                try:
+                    if not sock.recv(4096):
+                        print("Server disconnected.")
+                        sock.close()
+                        sock = None
+                except Exception:
+                    sock = None
+
+            changed = False
+            for player in list(players):
+                if player["dev"].fd not in readable:
+                    continue
+                try:
+                    for event in player["dev"].read():
+                        apply_mapping(player, event)
+                        if process_event(player, event):
+                            changed = True
+                except OSError as e:
+                    print(f"P{player['player']} device error: {e}")
+                    try:
+                        player["dev"].close()
+                    except Exception:
+                        pass
+                    players.remove(player)
+                    if not players:
+                        running = False
+
+            if changed and sock is not None:
+                states = [p["state"] for p in players]
+                packet = build_ds_packet(states, args.game, screen_w, screen_h)
+                try:
+                    sock.sendall(packet)
+                except Exception as e:
+                    print(f"Send error: {e}")
+                    sock = None
+
+    finally:
+        if sock:
+            try:
+                sock.close()
+            except Exception:
+                pass
+        for player in players:
+            if player.get("uinput"):
+                try:
+                    player["uinput"].close()
+                except Exception:
+                    pass
+            try:
+                player["dev"].ungrab()
+            except Exception:
+                pass
+            try:
+                player["dev"].close()
+            except Exception:
+                pass
+        print("Stopped.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Hi,
currently we can't use multiple guns on linux with wine, because wine is not supporting multiple rawmouse && merge all mouses input into a single one.

This patch serie add tcpinput instead rawinput in demulshooter , allowing a linux client to communicate through tcp with demulshooter directly.

I have use same kind of protocol than the unity plugins.

A linux python client is provided, connecting to demul  or directly to the unity plugins tcp server for the unity games.


I have tested all unity games, model2, typex, sega ringedge/ringwide, seganu games.  
Some games are not working (The House of The Dead : Remake for example, some arcadepc, but I think that not evertyhing is handled by demulshooter for theses games), but 90% of games are working.

